### PR TITLE
current day bug

### DIFF
--- a/src/pages/DayDetails/DayDetails.jsx
+++ b/src/pages/DayDetails/DayDetails.jsx
@@ -26,6 +26,7 @@ const DayDetails = (props) => {
 
   return (
     <>
+      <h1 className='date-heading'>{day ? day.date?.substring(4,15) : "..."}</h1>
       <div className='stand'>
         {/* Stand up */}
         <div className='stand-header'>

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -17,7 +17,6 @@ const Landing = ({ user, days, createDay, updateCurrentDay, currentDay, updateDa
             <div className='week'>
               <DayList updateCurrentDay={updateCurrentDay} days={week} />
             </div>
-            <h1 className='date-heading'>{currentDay?.date?.substring(4,15)}</h1>
           </div>
           <div>
             <DayDetails updateDay={updateDay} updateCurrentDay={updateCurrentDay} currentDay={currentDay} />


### PR DESCRIPTION
- Stand up / down edits pre populate so user does not have to start over. Removed useEffect that set current day in APp, which caused a bug where backing out of a form would set the current day to the first day in the days array - now backing out returns to the selected day.
- Create profile page to show all days and all jobs
- Create user avatar
- Stub style for profile page
- Hard refresh will still cause message to disappear, but it now stays when returning from a form.
