### PR TITLE
Clean job grid on profile.

### DIFF
--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -30,8 +30,6 @@ const Profile = (props) => {
       <h2 className={styles.message}>{jerbs.length} Applications over {days.length} days!</h2>
       <div className={styles.jobsFlex}>
         {jerbs.map((j, idx) => <button className={styles.fadollarsign} key={idx} onClick={()=> navToJobEditForm(j.day_id, j.id)}><i className="fa-solid fa-dollar-sign"></i></button>)}
-        {jerbs.map((j, idx) => <button className={styles.fadollarsign} key={idx} onClick={()=> navToJobEditForm(j.day_id, j.id)}><i className="fa-solid fa-dollar-sign"></i></button>)}
-        {jerbs.map((j, idx) => <button className={styles.fadollarsign} key={idx} onClick={()=> navToJobEditForm(j.day_id, j.id)}><i className="fa-solid fa-dollar-sign"></i></button>)}
       </div>
       <div className={styles.btnContainer}>
         <button className={styles.backBtn} onClick={()=> navigate("/")}>Back</button>

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -14,7 +14,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 15px;
-  height: 300px;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
- Styled details and landing
- Style profile page
- Fixed issue that prevented a heading from showing when the landing page refreshed.
- Clean up jobs on profile page. -- was looping multiple times to simulate a lot of jobs.
